### PR TITLE
Update config.vm.synced_folder

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,7 +57,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder "/Users/wchrisjohnson/src/vagrant_data", "/vagrant_data"
+  config.vm.synced_folder "~/src/vagrant_data", "/vagrant_data", :create => true
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.


### PR DESCRIPTION
Change the config.vm.synced_folder value to be more dynamic (not
hardcoded) and also allow it to be created if it doesn’t exist in order
to avoid install error
